### PR TITLE
add client-go auth support for cloud-providers

### DIFF
--- a/pkg/util/exec.go
+++ b/pkg/util/exec.go
@@ -7,6 +7,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/exec"
 	"k8s.io/kubectl/pkg/scheme"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // SetKubernetesDefaults hack is copied from kubectl/exec (unexported)


### PR DESCRIPTION
This fixes the issue I ran into yesterday with commands failing against my GKE cluster.